### PR TITLE
Registers Not allocating based on BitSize

### DIFF
--- a/LogicScript/Interpreting/Interpreter.cs
+++ b/LogicScript/Interpreting/Interpreter.cs
@@ -16,10 +16,7 @@ namespace LogicScript.Interpreting
                     throw new InterpreterException($"Output length mismatch: script requires {script.RegisteredOutputLength} but machine has {machine.OutputCount}");
             }
 
-			int registerSum = 0;
-			foreach (var register in script.Registers)
-				registerSum += register.BitSize;
-            machine.AllocateRegisters(registerSum);
+            machine.AllocateRegisters(script.Registers.Values.Sum(o => o.BitSize));
 
             Span<bool> input = stackalloc bool[machine.InputCount];
             machine.ReadInput(input);

--- a/LogicScript/Interpreting/Interpreter.cs
+++ b/LogicScript/Interpreting/Interpreter.cs
@@ -16,7 +16,10 @@ namespace LogicScript.Interpreting
                     throw new InterpreterException($"Output length mismatch: script requires {script.RegisteredOutputLength} but machine has {machine.OutputCount}");
             }
 
-            machine.AllocateRegisters(script.Registers.Count);
+			int registerSum = 0;
+			foreach (var register in script.Registers)
+				registerSum += register.BitSize;
+            machine.AllocateRegisters(registerSum);
 
             Span<bool> input = stackalloc bool[machine.InputCount];
             machine.ReadInput(input);

--- a/LogicScript/Interpreting/Interpreter.cs
+++ b/LogicScript/Interpreting/Interpreter.cs
@@ -16,7 +16,7 @@ namespace LogicScript.Interpreting
                     throw new InterpreterException($"Output length mismatch: script requires {script.RegisteredOutputLength} but machine has {machine.OutputCount}");
             }
 
-            machine.AllocateRegisters(script.Registers.Values.Sum(o => o.BitSize));
+            machine.AllocateRegisters(script.RegisteredRegisterLength);
 
             Span<bool> input = stackalloc bool[machine.InputCount];
             machine.ReadInput(input);

--- a/LogicScript/Parsing/Structures/Reference.cs
+++ b/LogicScript/Parsing/Structures/Reference.cs
@@ -48,7 +48,7 @@ namespace LogicScript.Parsing.Structures
                 MachinePorts.Input => "input",
                 MachinePorts.Output => "output",
                 MachinePorts.Register => "reg",
-                _ => throw new System.Exception("Unkonwn target")
+                _ => throw new System.Exception("Unknown target")
             };
 
             return $"{target}[{StartIndex}..{StartIndex + BitSize}]";

--- a/LogicScript/Script.cs
+++ b/LogicScript/Script.cs
@@ -20,6 +20,7 @@ namespace LogicScript
 
         internal int RegisteredInputLength => Inputs.Values.Sum(o => o.BitSize);
         internal int RegisteredOutputLength => Outputs.Values.Sum(o => o.BitSize);
+        internal int RegisteredRegisterLength => Registers.Values.Sum(o => o.BitSize);
 
         internal IList<Block> Blocks { get; } = new List<Block>();
 


### PR DESCRIPTION
Issue:
registers where only allocated by amount of references and not amount of bits required

Solution:
Counts bit sizes of all referenced registers and allocates

`This will need to be tested before integration`