### PR TITLE
Fixed Register Index supplied to IMachine.ReadRegister

### DIFF
--- a/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
+++ b/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
@@ -113,7 +113,11 @@ namespace LogicScript.Parsing.Visitors
                 return;
             }
 
-            int startIndex = dic.Values.Sum(o => o.BitSize);
+            int startIndex;
+            if (target == MachinePorts.Register)
+                startIndex = Script.Registers.Count;
+            else
+                startIndex = dic.Values.Sum(o => o.BitSize);
 
             dic.Add(name, new PortInfo(target, startIndex, (int)size, new(context.IDENT().Symbol)));
         }


### PR DESCRIPTION
Fixed the startIndex of registers so IMachine.ReadRegister/WriteRegiser receive a number they can actually index with.

Currently IMachine.AllocateRegisters receives a count of registers and ReadRegister/WriteRegister receive an index that's based around how many bits the register is, but not any info on how many bits the register is. Leading to an impossible scenario.

The script below 
```
reg'8 test
reg'2 test2
reg'5 test3
reg'2 test4
```
Would be expected to pass "0, 1, 2, 3" to `IMachine.ReadRegister` & `IMachine.WriteRegister` but instead passes "0, 8, 10, 15".

This makes it pass "0, 1, 2, 3"