### PR TITLE
Add port vectors

### DIFF
--- a/LogicScript.DX.LSP/Handlers/DocumentHighlightHandler.cs
+++ b/LogicScript.DX.LSP/Handlers/DocumentHighlightHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using LogicScript.Parsing.Structures;
 using LogicScript.Parsing.Structures.Expressions;
 using LogicScript.Parsing.Structures.Statements;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -42,7 +43,7 @@ namespace LogicScript.DX.LSP.Handlers
                     highlights.Add(new()
                     {
                         Kind = DocumentHighlightKind.Write,
-                        Range = assign.Reference.Span.ToRange()
+                        Range = assign.Reference is PortReference portRef ? portRef.PortSpan.ToRange() : assign.Reference.Span.ToRange()
                     });
                 }
                 else if (node is ReferenceExpression refExpr && refExpr.Reference.Port.Equals(port))
@@ -50,7 +51,7 @@ namespace LogicScript.DX.LSP.Handlers
                     highlights.Add(new()
                     {
                         Kind = DocumentHighlightKind.Read,
-                        Range = refExpr.Reference.Span.ToRange()
+                        Range = refExpr.Reference is PortReference portRef ? portRef.PortSpan.ToRange() : refExpr.Reference.Span.ToRange()
                     });
                 }
             }

--- a/LogicScript.DX.LSP/Handlers/HoverHandler.cs
+++ b/LogicScript.DX.LSP/Handlers/HoverHandler.cs
@@ -34,7 +34,7 @@ namespace LogicScript.DX.LSP.Handlers
                 typeof(Reference),
                 typeof(Expression),
                 typeof(DeclareLocalStatement),
-                typeof(PortValue),
+                typeof(PortValues),
             ]);
             var lines = new List<string>();
             int size;
@@ -83,7 +83,7 @@ namespace LogicScript.DX.LSP.Handlers
 
                 case PortValue portValue:
                     size = portValue.Value.Length;
-                    span = portValue.NameSpan;
+                    span = portValue.Span;
                     break;
 
                 default:

--- a/LogicScript.DX.LSP/Workspace.cs
+++ b/LogicScript.DX.LSP/Workspace.cs
@@ -129,7 +129,7 @@ namespace LogicScript.DX.LSP
                 Reference r => r.Port,
                 IPortInfo p => p,
                 PrintStringFormat.Interpolation interp => interp.Local,
-                PortValue portValue when TryGetScript(uri, out var script) && script.TryGetPort(portValue.Name, portValue.Ports, out var port) => port,
+                PortValues portValue when TryGetScript(uri, out var script) && script.TryGetPort(portValue.Name, portValue.Ports, out var port) => port,
                 _ => null
             };
         }

--- a/LogicScript.Tests/Benches/bit_operations.lsx
+++ b/LogicScript.Tests/Benches/bit_operations.lsx
@@ -1,0 +1,18 @@
+input'8 a
+input'8 b
+output'8 out
+
+reg'5 step
+
+assign out =
+    step == 0 ? a & b :
+    step == 1 ? a | b : 0;
+
+when *
+    step '= step + 1
+end
+
+@test (
+    a(0101b) b(1111b) => out(0101b),
+    a(0101b) b(1010b) => out(1111b),
+)

--- a/LogicScript.Tests/Benches/length.lsx
+++ b/LogicScript.Tests/Benches/length.lsx
@@ -1,23 +1,19 @@
 input one
 input'2 two
-output'7 out1
-output'7 out2
-output'7 out3
-output'7 out4
-output'7 out5
+output'7 out[5]
 
 reg'4 register
 
-assign out1 = len(out1)
-assign out2 = len(one)
-assign out3 = len(two)
-assign out4 = len(register)
+assign out[0] = len(out) / len(out[0])
+assign out[1] = len(one)
+assign out[2] = len(two)
+assign out[3] = len(register)
 
 when *
     local $local'5
-    out5 = len($local)
+    out[4] = len($local)
 end
 
 @test (
-    => out1(7) out2(1) out3(2) out4(4) out5(5),
+    => out(5, 1, 2, 4, 5),
 )

--- a/LogicScript.Tests/Benches/vectors.lsx
+++ b/LogicScript.Tests/Benches/vectors.lsx
@@ -1,0 +1,11 @@
+input'5 in_a[4]
+input'3 in_b[5]
+output'15 out[3]
+
+assign out[0] = len(in_b)
+assign out[1] = len(in_b) / len(in_b[0])
+assign out[2] = 4321
+
+@test (
+    => out(15, 5, 4321),
+)

--- a/LogicScript.Tests/LogicScript.Tests.csproj
+++ b/LogicScript.Tests/LogicScript.Tests.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="Nunit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="nunit" Version="4.6.1" />
+    <PackageReference Include="Nunit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LogicScript.Tests/TestExpressions.cs
+++ b/LogicScript.Tests/TestExpressions.cs
@@ -81,8 +81,8 @@ namespace LogicScript.Tests
         {
             var machine = new DummyMachine(new[] { false, true, true });
 
-            var a = new MachinePortInfo(MachinePorts.Input, 0, 1, default);
-            var b = new MachinePortInfo(MachinePorts.Input, 1, 2, default);
+            var a = new MachinePortInfo(MachinePorts.Input, 0, 1, 1, default);
+            var b = new MachinePortInfo(MachinePorts.Input, 1, 2, 1, default);
 
             Run(new Script()
             {
@@ -94,8 +94,8 @@ namespace LogicScript.Tests
                     new StartupBlock(default,
                         new ShowTaskStatement(default,
                             new BinaryOperatorExpression(default, Operator.Add,
-                                new ReferenceExpression(default, new PortReference(default, a)),
-                                new ReferenceExpression(default, new PortReference(default, b))
+                                new ReferenceExpression(default, new PortReference(default, a, null)),
+                                new ReferenceExpression(default, new PortReference(default, b, null))
                             )
                         )
                     ),
@@ -110,8 +110,8 @@ namespace LogicScript.Tests
         {
             var machine = new DummyMachine(registers: [1, 2]);
 
-            var a = new MachinePortInfo(MachinePorts.Register, 0, 1, default);
-            var b = new MachinePortInfo(MachinePorts.Register, 1, 1, default);
+            var a = new MachinePortInfo(MachinePorts.Register, 0, 1, 1, default);
+            var b = new MachinePortInfo(MachinePorts.Register, 1, 1, 1, default);
 
             Run(new Script()
             {
@@ -124,8 +124,8 @@ namespace LogicScript.Tests
                     new StartupBlock(default,
                         new ShowTaskStatement(default,
                             new BinaryOperatorExpression(default, Operator.Add,
-                                new ReferenceExpression(default, new PortReference(default, a)),
-                                new ReferenceExpression(default, new PortReference(default, b))
+                                new ReferenceExpression(default, new PortReference(default, a, null)),
+                                new ReferenceExpression(default, new PortReference(default, b, null))
                             )
                         )
                     ),

--- a/LogicScript/Compiling/Compiler.cs
+++ b/LogicScript/Compiling/Compiler.cs
@@ -277,10 +277,12 @@ namespace LogicScript.Compiling
 
         private Expression Compile(AssignStatement stmt)
         {
-            switch (stmt.Reference.Port)
+            switch (stmt.Reference)
             {
-                case MachinePortInfo port:
-                    switch (port.Target)
+                case PortReference port:
+                    var startIndex = ComputePortOffset(port);
+
+                    switch (port.PortInfo.Target)
                     {
                         case MachinePorts.Output:
                             var value = Compile(stmt.Value, port.BitSize == 1);
@@ -290,7 +292,7 @@ namespace LogicScript.Compiling
                                 return Expression.Call(
                                     Machine,
                                     typeof(IMachine).GetMethod(nameof(IMachine.WriteOutput))!,
-                                    Expression.Constant(port.StartIndex),
+                                    startIndex,
                                     value
                                 );
                             }
@@ -299,7 +301,7 @@ namespace LogicScript.Compiling
                                 return Expression.Call(
                                     Machine,
                                     typeof(IMachine).GetMethod(nameof(IMachine.WriteOutputs)),
-                                    Expression.Constant(port.StartIndex),
+                                    startIndex,
                                     Expression.New(
                                         typeof(BitsValue).GetConstructor([typeof(ulong), typeof(int)])!,
                                         value,
@@ -312,15 +314,15 @@ namespace LogicScript.Compiling
                             return Expression.Call(
                                 Machine,
                                 typeof(IMachine).GetMethod(nameof(IMachine.WriteRegister)),
-                                Expression.Constant(port.StartIndex),
+                                startIndex,
                                 Compile(stmt.Value, false)
                             );
                     }
                     throw new NotImplementedException();
 
-                case LocalInfo local:
+                case LocalReference local:
                     {
-                        var localVar = FindLocal(local);
+                        var localVar = FindLocal(local.LocalInfo);
                         var value = Compile(stmt.Value, false);
 
                         return Expression.Assign(localVar, value);
@@ -351,7 +353,7 @@ namespace LogicScript.Compiling
                 TernaryOperatorExpression t => Compile(t, canReturnBool),
                 TruncateExpression t => Compile(t.Operand, canReturnBool), // Truncating is a no-op at runtime since bit size is determined at compile-time
                 UnaryOperatorExpression u => Compile(u, canReturnBool),
-                ReferenceLengthExpression r => Expression.Constant((ulong)r.Reference.BitSize),
+                ReferenceLengthExpression r => Expression.Constant((ulong)r.Value),
                 _ => throw new NotImplementedException()
             };
         }
@@ -480,27 +482,34 @@ namespace LogicScript.Compiling
 
         private Expression Compile(ReferenceExpression expr, bool canReturnBool)
         {
-            return expr.Reference.Port switch
+            switch (expr.Reference)
             {
-                MachinePortInfo port => port.Target switch
-                {
-                    MachinePorts.Input => expr.BitSize == 1 && canReturnBool
-                        ? Expression.Call(
+                case LocalReference local:
+                    return FindLocal(local.LocalInfo);
+
+                case PortReference port:
+                    var startIndex = ComputePortOffset(port);
+
+                    return port.PortInfo.Target switch
+                    {
+                        MachinePorts.Input => expr.BitSize == 1 && canReturnBool
+                            ? Expression.Call(
+                                Machine,
+                                typeof(IMachine).GetMethod(nameof(IMachine.ReadInput)),
+                                startIndex
+                            )
+                            : ReadInput(startIndex, port.BitSize),
+                        MachinePorts.Register => Expression.Call(
                             Machine,
-                            typeof(IMachine).GetMethod(nameof(IMachine.ReadInput)),
-                            Expression.Constant(port.StartIndex)
-                        )
-                        : ReadInput(port.StartIndex, port.BitSize),
-                    MachinePorts.Register => Expression.Call(
-                        Machine,
-                        typeof(IMachine).GetMethod(nameof(IMachine.ReadRegister)),
-                        Expression.Constant(port.StartIndex)
-                    ),
-                    _ => throw new NotImplementedException()
-                },
-                LocalInfo local => FindLocal(local),
-                _ => throw new NotImplementedException()
-            };
+                            typeof(IMachine).GetMethod(nameof(IMachine.ReadRegister)),
+                            startIndex
+                        ),
+                        _ => throw new NotImplementedException()
+                    };
+
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         private ParameterExpression FindLocal(LocalInfo info)
@@ -561,7 +570,7 @@ namespace LogicScript.Compiling
             return convert ? Expression.Condition(boolExpr, Expression.Constant(1UL), Expression.Constant(0UL)) : boolExpr;
         }
 
-        private Expression ReadInput(int start, int size)
+        private Expression ReadInput(Expression start, int size)
         {
             return Expression.Field(
                 Expression.Call(
@@ -570,11 +579,38 @@ namespace LogicScript.Compiling
                         typeof(IMachine).GetMethod(nameof(IMachine.ReadInputs))
                     ),
                     typeof(BitsValue).GetMethod(nameof(BitsValue.Slice)),
-                    Expression.Constant(start),
+                    start,
                     Expression.Constant(size)
                 ),
                 typeof(BitsValue).GetField(nameof(BitsValue.Number))
             );
+        }
+
+
+        private Expression ComputePortOffset(PortReference port)
+        {
+            if (port.VectorIndex == null)
+            {
+                return Expression.Constant(port.StartIndex);
+            }
+            else
+            {
+                if (port.VectorIndex.IsConstant)
+                {
+                    var vectorIndex = (int)GetConstantValue(port.VectorIndex);
+                    return Expression.Constant(port.StartIndex + port.BitSize * vectorIndex);
+                }
+                else
+                {
+                    return Expression.Add(
+                        Expression.Constant(port.StartIndex),
+                        Expression.Multiply(
+                            Expression.Constant(port.BitSize),
+                            Compile(port.VectorIndex, false)
+                        )
+                    );
+                }
+            }
         }
     }
 }

--- a/LogicScript/Data/BitsValue.cs
+++ b/LogicScript/Data/BitsValue.cs
@@ -176,5 +176,7 @@ namespace LogicScript.Data
         public static bool operator !=(BitsValue left, int right) => left.Number != (ulong)right;
         public static bool operator >(BitsValue left, BitsValue right) => left.Number > right.Number;
         public static bool operator <(BitsValue left, BitsValue right) => left.Number < right.Number;
+
+        public static explicit operator int(BitsValue v) => (int)v.Number;
     }
 }

--- a/LogicScript/Interpreting/Interpreter.Expressions.cs
+++ b/LogicScript/Interpreting/Interpreter.Expressions.cs
@@ -19,6 +19,7 @@ namespace LogicScript.Interpreting
                 TruncateExpression trunc => Visit(trunc),
                 SliceExpression slice => Visit(slice),
                 ReferenceLengthExpression len => new((ulong)len.Reference.BitSize, 7),
+                PlaceholderExpression => throw new InterpreterException("Tried to execute placeholder"),
                 _ => throw new InterpreterException("Unknown expression", expr.Span.Start),
             };
         }
@@ -27,11 +28,15 @@ namespace LogicScript.Interpreting
         {
             if (expr.Reference is PortReference port)
             {
+                var vectorIndex = port.VectorIndex == null ? 0 : (int)Visit(port.VectorIndex).Number;
+                if (vectorIndex >= port.PortInfo.VectorLength)
+                    throw new InterpreterException("Vector index out of range", port.VectorIndex!.Span);
+
                 return port.PortInfo.Target switch
                 {
                     MachinePorts.Output => throw new InterpreterException("Cannot read from output", expr.Span),
-                    MachinePorts.Input => new BitsValue(Machine!.ReadInputs().Slice(port.StartIndex, port.BitSize)),
-                    MachinePorts.Register => Machine!.ReadRegister(port.StartIndex),
+                    MachinePorts.Input => new BitsValue(Machine!.ReadInputs().Slice(port.StartIndex + port.BitSize * vectorIndex, port.BitSize)),
+                    MachinePorts.Register => Machine!.ReadRegister(port.StartIndex + port.BitSize * vectorIndex),
                     _ => throw new InterpreterException("Unknown reference target", expr.Span),
                 };
             }

--- a/LogicScript/Interpreting/Interpreter.Expressions.cs
+++ b/LogicScript/Interpreting/Interpreter.Expressions.cs
@@ -18,7 +18,7 @@ namespace LogicScript.Interpreting
                 UnaryOperatorExpression unary => Visit(unary),
                 TruncateExpression trunc => Visit(trunc),
                 SliceExpression slice => Visit(slice),
-                ReferenceLengthExpression len => new((ulong)len.Reference.BitSize, 7),
+                ReferenceLengthExpression len => len.Value,
                 PlaceholderExpression => throw new InterpreterException("Tried to execute placeholder"),
                 _ => throw new InterpreterException("Unknown expression", expr.Span.Start),
             };

--- a/LogicScript/Interpreting/Interpreter.Statements.cs
+++ b/LogicScript/Interpreting/Interpreter.Statements.cs
@@ -60,6 +60,10 @@ namespace LogicScript.Interpreting
 
             if (stmt.Reference is PortReference port)
             {
+                var vectorIndex = port.VectorIndex == null ? 0 : (int)Visit(port.VectorIndex).Number;
+                if (vectorIndex >= port.PortInfo.VectorLength)
+                    throw new InterpreterException("Vector index out of range", port.VectorIndex!.Span);
+
                 switch (port.PortInfo.Target)
                 {
                     case MachinePorts.Input:
@@ -69,11 +73,11 @@ namespace LogicScript.Interpreting
                         if (value.Length > port.BitSize)
                             throw new InterpreterException("Value is longer than output", stmt.Span);
 
-                        Machine!.WriteOutputs(port.StartIndex, new(value.Bits));
+                        Machine!.WriteOutputs(port.StartIndex + port.BitSize * vectorIndex, new(value.Bits));
                         break;
 
                     case MachinePorts.Register:
-                        Machine!.WriteRegister(port.StartIndex, value);
+                        Machine!.WriteRegister(port.StartIndex + port.BitSize * vectorIndex, value);
                         break;
 
                     default:

--- a/LogicScript/LogicScript.g4
+++ b/LogicScript/LogicScript.g4
@@ -9,7 +9,7 @@ test_step           : WS* (step_action | step_repeat) COMMA ;
 step_action         : inputs=step_ports WS* ARROW WS* outputs=step_ports ;
 step_repeat         : '+' DEC_NUMBER ;
 step_ports          : (step_portvalue (WS+ step_portvalue)*)? ;
-step_portvalue      : port=IDENT LPAREN value=expression RPAREN ;
+step_portvalue      : port=IDENT LPAREN expression (wsnl ',' wsnl expression)* RPAREN ;
 
 declaration         : decl_const | decl_input | decl_output | decl_register | decl_when | decl_startup | decl_assign ;
 decl_const          : 'const' WS+ IDENT WS+ EQUALS WS+ expression ;

--- a/LogicScript/LogicScript.g4
+++ b/LogicScript/LogicScript.g4
@@ -20,7 +20,7 @@ decl_when           : 'when' space=WS+ (cond=expression | any='*') NL+ block 'en
 decl_startup        : 'startup' WS* NL+ block 'end' ;
 decl_assign         : 'assign' WS+ stmt_assign ;
 
-port_info           : ('\'' size=expression)? WS+ IDENT ;
+port_info           : ('\'' size=expression)? WS+ IDENT simple_indexer? ;
 
 block               : (wsnl stmt WS* NL wsnl)* wsnl ;
 
@@ -55,7 +55,7 @@ expression          : LPAREN wsnl expression wsnl RPAREN                        
                     | LPAREN wsnl expression wsnl RPAREN '\'' size=expression   # exprTrunc
                     | funcName=IDENT LPAREN wsnl expression wsnl RPAREN         # exprCall
                     | 'len' LPAREN wsnl (reference | expression) wsnl RPAREN    # exprLength
-                    | expression indexer                                        # exprSlice
+                    | expression slice_indexer                                  # exprSlice
                     | NOT expression                                            # exprNegate
                     | expression wsnl op=(OR | AND) wsnl expression             # exprAndOr
                     | expression wsnl XOR wsnl expression                       # exprXor
@@ -83,14 +83,15 @@ atom                : reference
 number              : DEC_NUMBER | BIN_NUMBER | HEX_NUMBER ;
 
 reference           : VARIABLE                      # refLocal
+                    | IDENT simple_indexer          # refIndex
                     | IDENT                         # refPort
-                    // | reference indexer             # refSlice
                     ;
 
 wsnl                : (WS | NL)* ;
 wsnl_req            : (WS | NL)+ ;
 
-indexer             : '[' lr=('>' | '<')? WS* offset=expression wsnl (COMMA WS* len=expression)? ']' ;
+slice_indexer       : '{' lr=('>' | '<')? WS* offset=expression wsnl (COMMA WS* len=expression)? '}' ;
+simple_indexer      : '[' index=expression ']' ;
 
 /*
  * Lexer Rules

--- a/LogicScript/Parsing/Structures/Expressions/ReferenceLengthExpression.cs
+++ b/LogicScript/Parsing/Structures/Expressions/ReferenceLengthExpression.cs
@@ -14,7 +14,7 @@ namespace LogicScript.Parsing.Structures.Expressions
             get
             {
                 if (Reference is PortReference portRef)
-                    return portRef.PortInfo.BitSize * portRef.PortInfo.VectorLength;
+                    return portRef.VectorIndex != null ? portRef.PortInfo.BitSize : portRef.PortInfo.BitSize * portRef.PortInfo.VectorLength;
 
                 return Reference.BitSize;
             }

--- a/LogicScript/Parsing/Structures/Expressions/ReferenceLengthExpression.cs
+++ b/LogicScript/Parsing/Structures/Expressions/ReferenceLengthExpression.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace LogicScript.Parsing.Structures.Expressions
 {
     internal sealed class ReferenceLengthExpression(SourceSpan span, Reference reference) : Expression(span)
@@ -5,7 +7,18 @@ namespace LogicScript.Parsing.Structures.Expressions
         public Reference Reference { get; } = reference;
 
         public override bool IsConstant => true;
-        public override int BitSize => 7;
+        public override int BitSize => (int)Math.Ceiling(Math.Log(Value, 2));
+
+        public int Value
+        {
+            get
+            {
+                if (Reference is PortReference portRef)
+                    return portRef.PortInfo.BitSize * portRef.PortInfo.VectorLength;
+
+                return Reference.BitSize;
+            }
+        }
 
         public override string ToString() => $"len({Reference})";
     }

--- a/LogicScript/Parsing/Structures/PortInfo.cs
+++ b/LogicScript/Parsing/Structures/PortInfo.cs
@@ -12,7 +12,8 @@ namespace LogicScript.Parsing.Structures
     {
         Input,
         Output,
-        Register
+        Register,
+        Placeholder
     }
 
     public readonly struct MachinePortInfo : IPortInfo
@@ -20,14 +21,19 @@ namespace LogicScript.Parsing.Structures
         public MachinePorts Target { get; }
         public int StartIndex { get; }
         public int BitSize { get; }
+        public int VectorLength { get; }
 
         public SourceSpan Span { get; }
 
-        internal MachinePortInfo(MachinePorts target, int index, int bitSize, SourceSpan span)
+        internal MachinePortInfo(MachinePorts target, int index, int bitSize, int vectorLength, SourceSpan span)
         {
+            if (vectorLength <= 0)
+                throw new ArgumentOutOfRangeException(nameof(vectorLength), "Vector length must be one or greater.");
+
             this.Target = target;
             this.StartIndex = index;
             this.BitSize = bitSize;
+            this.VectorLength = vectorLength;
             this.Span = span;
         }
 

--- a/LogicScript/Parsing/Structures/Reference.cs
+++ b/LogicScript/Parsing/Structures/Reference.cs
@@ -20,9 +20,10 @@ namespace LogicScript.Parsing.Structures
         }
     }
 
-    internal sealed class PortReference(SourceSpan span, MachinePortInfo port, Expression? vectorIndex) : Reference(span)
+    internal sealed class PortReference(SourceSpan span, SourceSpan portSpan, MachinePortInfo port, Expression? vectorIndex) : Reference(span)
     {
         public MachinePortInfo PortInfo { get; } = port;
+        public SourceSpan PortSpan { get; } = portSpan;
 
         public override IPortInfo Port => PortInfo;
 

--- a/LogicScript/Parsing/Structures/Reference.cs
+++ b/LogicScript/Parsing/Structures/Reference.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using LogicScript.Parsing.Structures.Expressions;
 
 namespace LogicScript.Parsing.Structures
 {
@@ -19,16 +20,17 @@ namespace LogicScript.Parsing.Structures
         }
     }
 
-    internal sealed class PortReference(SourceSpan span, MachinePortInfo port) : Reference(span)
+    internal sealed class PortReference(SourceSpan span, MachinePortInfo port, Expression? vectorIndex) : Reference(span)
     {
         public MachinePortInfo PortInfo { get; } = port;
 
         public override IPortInfo Port => PortInfo;
 
         public int StartIndex => PortInfo.StartIndex;
+        public Expression? VectorIndex { get; } = vectorIndex;
 
-        public override bool IsWritable => PortInfo.Target is MachinePorts.Output or MachinePorts.Register;
-        public override bool IsReadable => PortInfo.Target is MachinePorts.Input or MachinePorts.Register;
+        public override bool IsWritable => PortInfo.Target is MachinePorts.Output or MachinePorts.Register or MachinePorts.Placeholder;
+        public override bool IsReadable => PortInfo.Target is MachinePorts.Input or MachinePorts.Register or MachinePorts.Placeholder;
 
         public override string ToString()
         {
@@ -37,6 +39,7 @@ namespace LogicScript.Parsing.Structures
                 MachinePorts.Input => "input",
                 MachinePorts.Output => "output",
                 MachinePorts.Register => "reg",
+                MachinePorts.Placeholder => "<placeholder>",
                 _ => throw new System.Exception("Unknown target")
             };
 

--- a/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
+++ b/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
@@ -99,12 +99,12 @@ namespace LogicScript.Parsing.Visitors
 
         private void Visit(LogicScriptParser.Port_infoContext context, IDictionary<string, MachinePortInfo> dic, MachinePorts target)
         {
-            int size = context.size == null ? 1 : context.size.GetConstantValue(Context);
+            int size = context.size == null ? 1 : (int)context.size.GetConstantValue(Context);
 
             if (size > BitsValue.BitSize)
                 Errors.AddError($"The maximum bit size is {BitsValue.BitSize}", context.Span());
 
-            int length = context.simple_indexer() == null ? 1 : context.simple_indexer().index.GetConstantValue(Context);
+            int length = context.simple_indexer() == null ? 1 : (int)context.simple_indexer().index.GetConstantValue(Context);
 
             if (length <= 0)
             {

--- a/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
+++ b/LogicScript/Parsing/Visitors/DeclarationVisitor.cs
@@ -99,10 +99,18 @@ namespace LogicScript.Parsing.Visitors
 
         private void Visit(LogicScriptParser.Port_infoContext context, IDictionary<string, MachinePortInfo> dic, MachinePorts target)
         {
-            var size = context.size == null ? 1 : context.size.GetConstantValue(Context);
+            int size = context.size == null ? 1 : context.size.GetConstantValue(Context);
 
             if (size > BitsValue.BitSize)
                 Errors.AddError($"The maximum bit size is {BitsValue.BitSize}", context.Span());
+
+            int length = context.simple_indexer() == null ? 1 : context.simple_indexer().index.GetConstantValue(Context);
+
+            if (length <= 0)
+            {
+                Errors.AddError("Vectors length must be greater than zero", context.Span());
+                length = 1;
+            }
 
             var name = context.IDENT()?.GetText();
             if (name == null)
@@ -119,7 +127,7 @@ namespace LogicScript.Parsing.Visitors
 
             int startIndex = dic.Values.Sum(o => o.BitSize);
 
-            dic.Add(name, new MachinePortInfo(target, startIndex, size, new(context.IDENT().Symbol)));
+            dic.Add(name, new MachinePortInfo(target, startIndex, size, length, new(context.IDENT().Symbol)));
         }
     }
 }

--- a/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
@@ -252,7 +252,7 @@ namespace LogicScript.Parsing.Visitors
 
             if (context.reference() != null)
             {
-                var reference = new ReferenceVisitor(Context, MaxBitSize).Visit(context.reference());
+                var reference = new ReferenceVisitor(Context, MaxBitSize, true).Visit(context.reference());
                 return new ReferenceLengthExpression(context.Span(), reference);
             }
 

--- a/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
@@ -118,7 +118,7 @@ namespace LogicScript.Parsing.Visitors
                 offset = new ExpressionVisitor(Context).Visit(context.slice_indexer().offset);
             }
 
-            var length = context.slice_indexer().len == null ? 1 : context.slice_indexer().len.GetConstantValue(Context.Script);
+            var length = context.slice_indexer().len == null ? 1 : (int)context.slice_indexer().len.GetConstantValue(Context.Script);
             var sliceExpr = new SliceExpression(context.Span(), operand, start, offset, length);
 
             if (length == 0)
@@ -279,7 +279,7 @@ namespace LogicScript.Parsing.Visitors
         {
             // Create a new unbounded expression visitor since we don't care about length
             var operand = new ExpressionVisitor(Context).Visit(context.expression(0));
-            var size = context.size.GetConstantValue(Context.Script);
+            var size = (int)context.size.GetConstantValue(Context.Script);
 
             return new TruncateExpression(context.Span(), operand, size);
         }

--- a/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ExpressionVisitor.cs
@@ -59,7 +59,7 @@ namespace LogicScript.Parsing.Visitors
             if (Context.IsInConstant)
                 Context.Errors.AddError("You can only reference constants from other constants", context.Span(), true);
 
-            var @ref = new ReferenceVisitor(Context).Visit(context);
+            var @ref = new ReferenceVisitor(Context, MaxBitSize).Visit(context);
 
             return new ReferenceExpression(context.Span(), @ref);
         }
@@ -72,10 +72,20 @@ namespace LogicScript.Parsing.Visitors
             if (Context.IsInConstant)
                 Context.Errors.AddError("You can only reference constants from other constants", context.Span(), true);
 
-            var @ref = new ReferenceVisitor(Context).Visit(context);
+            var @ref = new ReferenceVisitor(Context, MaxBitSize).Visit(context);
 
             if (!@ref.IsReadable)
                 Context.Errors.AddError("An identifier in an expression must be readable", context.Span());
+
+            return new ReferenceExpression(context.Span(), @ref);
+        }
+
+        public override Expression VisitRefIndex([NotNull] LogicScriptParser.RefIndexContext context)
+        {
+            if (Context.IsInConstant)
+                Context.Errors.AddError("You can only reference constants from other constants", context.Span(), true);
+
+            var @ref = new ReferenceVisitor(Context, MaxBitSize).Visit(context);
 
             return new ReferenceExpression(context.Span(), @ref);
         }
@@ -89,30 +99,30 @@ namespace LogicScript.Parsing.Visitors
         {
             // Create a new unbounded expression visitor, since we only care about the slice length, not the operand's
             var operand = new ExpressionVisitor(Context).Visit(context.expression());
-            var start = context.indexer().lr?.Text switch
+            var start = context.slice_indexer().lr?.Text switch
             {
                 ">" => IndexStart.Right,
                 "<" or null => IndexStart.Left,
-                _ => throw new ParseException("Unknown index start position", context.indexer().Span())
+                _ => throw new ParseException("Unknown index start position", context.slice_indexer().Span())
             };
 
             Expression offset;
 
-            if (context.indexer().offset == null)
+            if (context.slice_indexer().offset == null)
             {
-                Context.Errors.AddError("Missing indexer offset", context.indexer().Span());
-                offset = new NumberLiteralExpression(context.indexer().Span(), BitsValue.Zero);
+                Context.Errors.AddError("Missing indexer offset", context.slice_indexer().Span());
+                offset = new NumberLiteralExpression(context.slice_indexer().Span(), BitsValue.Zero);
             }
             else
             {
-                offset = new ExpressionVisitor(Context).Visit(context.indexer().offset);
+                offset = new ExpressionVisitor(Context).Visit(context.slice_indexer().offset);
             }
 
-            var length = context.indexer().len == null ? 1 : context.indexer().len.GetConstantValue(Context.Script);
+            var length = context.slice_indexer().len == null ? 1 : context.slice_indexer().len.GetConstantValue(Context.Script);
             var sliceExpr = new SliceExpression(context.Span(), operand, start, offset, length);
 
             if (length == 0)
-                Context.Errors.AddError("Slice length cannot be zero", context.indexer().len.Span());
+                Context.Errors.AddError("Slice length cannot be zero", context.slice_indexer().len.Span());
 
             if (offset.IsConstant)
             {
@@ -120,10 +130,10 @@ namespace LogicScript.Parsing.Visitors
                 var offsetValue = (int)offset.GetConstantValue().Number;
 
                 if (offsetValue >= operand.BitSize)
-                    Context.Errors.AddError("Offset is out of bounds", context.indexer().offset.Span());
+                    Context.Errors.AddError("Offset is out of bounds", context.slice_indexer().offset.Span());
 
                 if (offsetValue + length > operand.BitSize)
-                    Context.Errors.AddError("Slice is out of bounds", context.indexer().Span());
+                    Context.Errors.AddError("Slice is out of bounds", context.slice_indexer().Span());
             }
 
             if (MaxBitSize != 0 && length > MaxBitSize)
@@ -242,7 +252,7 @@ namespace LogicScript.Parsing.Visitors
 
             if (context.reference() != null)
             {
-                var reference = new ReferenceVisitor(Context).Visit(context.reference());
+                var reference = new ReferenceVisitor(Context, MaxBitSize).Visit(context.reference());
                 return new ReferenceLengthExpression(context.Span(), reference);
             }
 

--- a/LogicScript/Parsing/Visitors/Extensions.cs
+++ b/LogicScript/Parsing/Visitors/Extensions.cs
@@ -7,8 +7,8 @@ namespace LogicScript.Parsing.Visitors
 {
     internal static class Extensions
     {
-        public static int GetConstantValue(this IParseTree tree, ScriptContext context)
-            => (int)new ExpressionVisitor(new BlockContext(context, null, true)).Visit(tree).GetConstantValue().Number;
+        public static BitsValue GetConstantValue(this IParseTree tree, ScriptContext context)
+            => new ExpressionVisitor(new BlockContext(context, null, true)).Visit(tree).GetConstantValue();
 
         public static BitsValue GetConstantValue(this Expression expr)
             => Interpreter.GetConstantValue(expr);

--- a/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
@@ -1,27 +1,36 @@
-﻿using Antlr4.Runtime.Misc;
+﻿using System;
+using Antlr4.Runtime.Misc;
 using LogicScript.Parsing.Structures;
 
 namespace LogicScript.Parsing.Visitors
 {
-    internal class ReferenceVisitor(BlockContext context) : LogicScriptBaseVisitor<Reference>
+    internal class ReferenceVisitor(BlockContext context, int defaultBitSize) : LogicScriptBaseVisitor<Reference>
     {
         private readonly BlockContext Context = context;
 
+        private MachinePortInfo GetPortInfo(string name, SourceSpan nameSpan)
+        {
+            MachinePorts? target =
+                          Context.Script.Script.Inputs.TryGetValue(name, out var port) ? MachinePorts.Input
+                        : Context.Script.Script.Outputs.TryGetValue(name, out port) ? MachinePorts.Output
+                        : Context.Script.Script.Registers.TryGetValue(name, out port) ? MachinePorts.Register
+                        : MachinePorts.Placeholder;
+
+            if (target == MachinePorts.Placeholder)
+            {
+                Context.Errors.AddError($"Unknown port '{name}'", nameSpan);
+
+                return new(MachinePorts.Placeholder, 0, defaultBitSize, 1, nameSpan);
+            }
+
+            return port;
+        }
+
         public override Reference VisitRefPort([NotNull] LogicScriptParser.RefPortContext context)
         {
-            var identName = context.IDENT().GetText();
-            MachinePortInfo port;
+            var portInfo = GetPortInfo(context.IDENT().GetText(), context.IDENT().Symbol.Span());
 
-            MachinePorts? target =
-                          Context.Script.Script.Inputs.TryGetValue(identName, out port) ? MachinePorts.Input
-                        : Context.Script.Script.Outputs.TryGetValue(identName, out port) ? MachinePorts.Output
-                        : Context.Script.Script.Registers.TryGetValue(identName, out port) ? MachinePorts.Register
-                        : null;
-
-            if (target == null)
-                Context.Errors.AddError($"Unknown identifier '{identName}'", new SourceSpan(context.IDENT().Symbol), isFatal: true);
-
-            return new PortReference(context.Span(), port);
+            return new PortReference(context.Span(), portInfo, null);
         }
 
         public override Reference VisitRefLocal([NotNull] LogicScriptParser.RefLocalContext context)
@@ -35,6 +44,16 @@ namespace LogicScript.Parsing.Visitors
             }
 
             return new LocalReference(context.Span(), name, local);
+        }
+
+        public override Reference VisitRefIndex([NotNull] LogicScriptParser.RefIndexContext context)
+        {
+            var portInfo = GetPortInfo(context.IDENT().GetText(), context.IDENT().Symbol.Span());
+
+            int maxIndexerBitSize = (int)Math.Ceiling(Math.Log(portInfo.VectorLength, 2));
+            var index = new ExpressionVisitor(Context, maxIndexerBitSize).Visit(context.simple_indexer().index);
+
+            return new PortReference(context.Span(), portInfo, index);
         }
     }
 }

--- a/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
@@ -28,12 +28,13 @@ namespace LogicScript.Parsing.Visitors
 
         public override Reference VisitRefPort([NotNull] LogicScriptParser.RefPortContext context)
         {
-            var portInfo = GetPortInfo(context.IDENT().GetText(), context.IDENT().Symbol.Span());
+            var nameSpan = context.IDENT().Symbol.Span();
+            var portInfo = GetPortInfo(context.IDENT().GetText(), nameSpan);
 
             if (portInfo.VectorLength > 1 && !allowRawVectors)
                 Context.Errors.AddError("Vectored port must be indexed", context.Span());
 
-            return new PortReference(context.Span(), portInfo, null);
+            return new PortReference(context.Span(), nameSpan, portInfo, null);
         }
 
         public override Reference VisitRefLocal([NotNull] LogicScriptParser.RefLocalContext context)
@@ -51,12 +52,13 @@ namespace LogicScript.Parsing.Visitors
 
         public override Reference VisitRefIndex([NotNull] LogicScriptParser.RefIndexContext context)
         {
-            var portInfo = GetPortInfo(context.IDENT().GetText(), context.IDENT().Symbol.Span());
+            var nameSpan = context.IDENT().Symbol.Span();
+            var portInfo = GetPortInfo(context.IDENT().GetText(), nameSpan);
 
             int maxIndexerBitSize = (int)Math.Ceiling(Math.Log(portInfo.VectorLength, 2));
             var index = new ExpressionVisitor(Context, maxIndexerBitSize).Visit(context.simple_indexer().index);
 
-            return new PortReference(context.Span(), portInfo, index);
+            return new PortReference(context.Span(), nameSpan, portInfo, index);
         }
     }
 }

--- a/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ReferenceVisitor.cs
@@ -4,7 +4,7 @@ using LogicScript.Parsing.Structures;
 
 namespace LogicScript.Parsing.Visitors
 {
-    internal class ReferenceVisitor(BlockContext context, int defaultBitSize) : LogicScriptBaseVisitor<Reference>
+    internal class ReferenceVisitor(BlockContext context, int defaultBitSize = 0, bool allowRawVectors = false) : LogicScriptBaseVisitor<Reference>
     {
         private readonly BlockContext Context = context;
 
@@ -29,6 +29,9 @@ namespace LogicScript.Parsing.Visitors
         public override Reference VisitRefPort([NotNull] LogicScriptParser.RefPortContext context)
         {
             var portInfo = GetPortInfo(context.IDENT().GetText(), context.IDENT().Symbol.Span());
+
+            if (portInfo.VectorLength > 1 && !allowRawVectors)
+                Context.Errors.AddError("Vectored port must be indexed", context.Span());
 
             return new PortReference(context.Span(), portInfo, null);
         }

--- a/LogicScript/Parsing/Visitors/ScriptVisitor.cs
+++ b/LogicScript/Parsing/Visitors/ScriptVisitor.cs
@@ -1,4 +1,6 @@
 ﻿using Antlr4.Runtime.Misc;
+using LogicScript.Parsing.Structures;
+using LogicScript.Testing;
 
 namespace LogicScript.Parsing.Visitors
 {
@@ -25,17 +27,17 @@ namespace LogicScript.Parsing.Visitors
                 {
                     foreach (var input in step.Inputs)
                     {
-                        if (!script.Inputs.TryGetValue(input.Name, out var stepInput))
+                        if (!script.Inputs.TryGetValue(input.Name, out var inputPort))
                             errors.AddError($"Unknown input port '{input.Name}'", input.NameSpan);
-                        else if (stepInput.BitSize < input.Value.Length)
-                            errors.AddError("Value doesn't fit in port", input.ValueSpan);
+                        else
+                            CheckTestPort(inputPort, input);
                     }
                     foreach (var output in step.Outputs)
                     {
-                        if (!script.Outputs.TryGetValue(output.Name, out var stepOutput))
+                        if (!script.Outputs.TryGetValue(output.Name, out var outputPort))
                             errors.AddError($"Unknown output port '{output.Name}'", output.NameSpan);
-                        else if (stepOutput.BitSize < output.Value.Length)
-                            errors.AddError("Value doesn't fit in port", output.ValueSpan);
+                        else
+                            CheckTestPort(outputPort, output);
                     }
                 }
 
@@ -43,6 +45,20 @@ namespace LogicScript.Parsing.Visitors
             }
 
             return script;
+
+            void CheckTestPort(MachinePortInfo port, PortValues values)
+            {
+                if (values.Values.Length < port.VectorLength)
+                    errors.AddError("Not enough values to fill port vector", values.ValuesSpan);
+                else if (values.Values.Length > port.VectorLength)
+                    errors.AddError("Too many values for port vector", values.ValuesSpan);
+
+                foreach (var value in values.Values)
+                {
+                    if (value.Value.Length > port.BitSize)
+                        errors.AddError("Value doesn't fit in port", value.Span);
+                }
+            }
         }
     }
 }

--- a/LogicScript/Parsing/Visitors/StatementVisitor.cs
+++ b/LogicScript/Parsing/Visitors/StatementVisitor.cs
@@ -124,7 +124,7 @@ namespace LogicScript.Parsing.Visitors
             Expression? value = null;
 
             // If the variable has a bit size marker, we will use that size. Otherwise, we will later infer it from the value
-            int size = context.size == null ? 0 : context.size.GetConstantValue(BlockContext.Script);
+            int size = context.size == null ? 0 : (int)context.size.GetConstantValue(BlockContext.Script);
 
             if (context.expression() != null)
             {

--- a/LogicScript/Parsing/Visitors/StatementVisitor.cs
+++ b/LogicScript/Parsing/Visitors/StatementVisitor.cs
@@ -31,7 +31,7 @@ namespace LogicScript.Parsing.Visitors
 
         public override Statement VisitAssignRegular([NotNull] LogicScriptParser.AssignRegularContext context)
         {
-            var @ref = new ReferenceVisitor(BlockContext).Visit(context.reference());
+            var @ref = new ReferenceVisitor(BlockContext, 0).Visit(context.reference());
 
             if (!@ref.IsWritable)
                 Context.Errors.AddError("The left hand side of an assignment must be writable", context.reference().Span());
@@ -43,7 +43,7 @@ namespace LogicScript.Parsing.Visitors
 
         public override Statement VisitAssignTruncate([NotNull] LogicScriptParser.AssignTruncateContext context)
         {
-            var @ref = new ReferenceVisitor(BlockContext).Visit(context.reference());
+            var @ref = new ReferenceVisitor(BlockContext, 0).Visit(context.reference());
 
             if (!@ref.IsWritable)
                 Context.Errors.AddError("The left hand side of an assignment must be writable", context.reference().Span());

--- a/LogicScript/Parsing/Visitors/TestCaseVisitor.cs
+++ b/LogicScript/Parsing/Visitors/TestCaseVisitor.cs
@@ -50,13 +50,13 @@ namespace LogicScript.Parsing.Visitors
 
             return new(index++, name, steps, context.Span());
 
-            IEnumerable<PortValue> GetPorts(MachinePorts ports, LogicScriptParser.Step_portsContext ctx)
+            IEnumerable<PortValues> GetPorts(MachinePorts ports, LogicScriptParser.Step_portsContext ctx)
             {
                 var seen = new HashSet<string>();
 
                 foreach (var item in ctx.step_portvalue())
                 {
-                    if (item.value == null)
+                    if (item.expression().Length == 0)
                     {
                         errors.AddError("Missing port value", item.Span());
                         continue;
@@ -69,8 +69,8 @@ namespace LogicScript.Parsing.Visitors
                     }
                     seen.Add(item.port.Text);
 
-                    var value = item.value.GetConstantValue(script ?? new(new(), errors));
-                    yield return new PortValue(item.port.Text, ports, value, item.port.Span(), item.value.Span());
+                    var values = item.expression().Select(e => new PortValue(e.GetConstantValue(script ?? new(new(), errors)), e.Span())).ToArray();
+                    yield return new PortValues(item.port.Text, ports, values, item.port.Span());
                 }
             }
         }

--- a/LogicScript/Script.cs
+++ b/LogicScript/Script.cs
@@ -23,8 +23,8 @@ namespace LogicScript
         public IDictionary<string, BitsValue> Constants { get; } = new Dictionary<string, BitsValue>();
         public IList<TestCase> TestCases { get; } = [];
 
-        internal int RegisteredInputLength => Inputs.Values.Sum(o => o.BitSize);
-        internal int RegisteredOutputLength => Outputs.Values.Sum(o => o.BitSize);
+        internal int RegisteredInputLength => Inputs.Values.Sum(o => o.BitSize * o.VectorLength);
+        internal int RegisteredOutputLength => Outputs.Values.Sum(o => o.BitSize * o.VectorLength);
 
         internal IList<Block> Blocks { get; } = [];
 

--- a/LogicScript/Testing/CaseStep.cs
+++ b/LogicScript/Testing/CaseStep.cs
@@ -6,17 +6,27 @@ using LogicScript.Parsing.Structures;
 
 namespace LogicScript.Testing
 {
-    public record struct PortValue(string Name, MachinePorts Ports, BitsValue Value, SourceSpan NameSpan, SourceSpan ValueSpan) : ICodeNode
+    public readonly record struct PortValue(BitsValue Value, SourceSpan Span) : ICodeNode
     {
-        readonly SourceSpan ICodeNode.Span => NameSpan;
-
         public readonly IEnumerable<ICodeNode> GetChildren()
         {
             yield break;
         }
     }
 
-    public record CaseStep(IList<PortValue> Inputs, IList<PortValue> Outputs, SourceSpan Span) : ICodeNode
+    public readonly record struct PortValues(string Name, MachinePorts Ports, PortValue[] Values, SourceSpan NameSpan) : ICodeNode
+    {
+        readonly SourceSpan ICodeNode.Span => NameSpan;
+
+        public SourceSpan ValuesSpan => new(Values[0].Span.Start, Values[Values.Length - 1].Span.End);
+
+        public IEnumerable<ICodeNode> GetChildren()
+        {
+            yield break;
+        }
+    }
+
+    public record CaseStep(IList<PortValues> Inputs, IList<PortValues> Outputs, SourceSpan Span) : ICodeNode
     {
         public IEnumerable<ICodeNode> GetChildren()
         {

--- a/LogicScript/Testing/Results/CaseResult.cs
+++ b/LogicScript/Testing/Results/CaseResult.cs
@@ -36,11 +36,11 @@ namespace LogicScript.Testing.Results
 
         public int StepIndex { get; }
         public SourceSpan StepSpan { get; }
-        public IDictionary<string, BitsValue> Inputs { get; }
-        public IDictionary<string, BitsValue> ExpectedOutputs { get; }
-        public IDictionary<string, BitsValue> MismatchedOutputs { get; }
+        public IDictionary<string, BitsValue[]> Inputs { get; }
+        public IDictionary<string, BitsValue[]> ExpectedOutputs { get; }
+        public IDictionary<string, BitsValue[]> MismatchedOutputs { get; }
 
-        internal FailedStepCaseResult(TestCase testCase, IReadOnlyCollection<string> printedLines, int stepIndex, SourceSpan stepSpan, IDictionary<string, BitsValue> inputs, IDictionary<string, BitsValue> expectedOutputs, IDictionary<string, BitsValue> mismatchedOutputs) : base(testCase, printedLines)
+        internal FailedStepCaseResult(TestCase testCase, IReadOnlyCollection<string> printedLines, int stepIndex, SourceSpan stepSpan, IDictionary<string, BitsValue[]> inputs, IDictionary<string, BitsValue[]> expectedOutputs, IDictionary<string, BitsValue[]> mismatchedOutputs) : base(testCase, printedLines)
         {
             this.StepIndex = stepIndex;
             this.StepSpan = stepSpan;
@@ -62,9 +62,9 @@ namespace LogicScript.Testing.Results
 
             return msg.ToString();
 
-            static string FormatIO(IDictionary<string, BitsValue> values)
+            static string FormatIO(IDictionary<string, BitsValue[]> values)
             {
-                return string.Join(' ', values.OrderBy(e => e.Key).Select(e => $"{e.Key}({e.Value.Number})").ToArray());
+                return string.Join(' ', values.OrderBy(e => e.Key).Select(e => $"{e.Key}({string.Join(", ", e.Value)})").ToArray());
             }
         }
     }

--- a/LogicScript/Testing/TestCase.cs
+++ b/LogicScript/Testing/TestCase.cs
@@ -37,9 +37,13 @@ namespace LogicScript.Testing
                     if (!script.Inputs.TryGetValue(input.Name, out var port))
                         throw new ArgumentException($"Unknown input port '{input.Name}'");
 
-                    var expandedValue = new BitsValue(input.Value.Number, port.BitSize);
+                    for (int i = 0; i < input.Values.Length; i++)
+                    {
+                        int vectorStart = port.StartIndex + i * port.BitSize;
+                        var expandedValue = new BitsValue(input.Values[i].Value.Number, port.BitSize);
 
-                    expandedValue.Bits.CopyTo(machine.Inputs.AsSpan()[port.StartIndex..(port.StartIndex + port.BitSize)]);
+                        expandedValue.Bits.CopyTo(machine.Inputs.AsSpan()[vectorStart..(vectorStart + port.BitSize)]);
+                    }
                 }
 
                 try
@@ -57,25 +61,28 @@ namespace LogicScript.Testing
                 hasRunStartup = true;
                 stepsRan++;
 
-                var mismatchedOutputs = new Dictionary<string, BitsValue>();
+                var mismatchedOutputs = new Dictionary<string, BitsValue[]>();
                 foreach (var output in step.Outputs)
                 {
                     if (!script.Outputs.TryGetValue(output.Name, out var port))
                         throw new ArgumentException($"Unknown output port '{output.Name}'");
 
-                    var machineValue = new BitsValue(machine.Outputs[port.StartIndex..(port.StartIndex + port.BitSize)]);
-
-                    var expandedValue = new BitsValue(output.Value.Number, port.BitSize);
-                    if (output.Value != machineValue)
+                    var machineValues = Enumerable.Range(0, output.Values.Length).Select(i =>
                     {
-                        mismatchedOutputs[output.Name] = machineValue;
-                    }
+                        int vectorStart = port.StartIndex + i * port.BitSize;
+                        return new BitsValue(machine.Outputs[vectorStart..(vectorStart + port.BitSize)]);
+                    });
+
+                    bool mismatched = !machineValues.SequenceEqual(output.Values.Select(v => v.Value));
+
+                    if (mismatched)
+                        mismatchedOutputs.Add(output.Name, machineValues.ToArray());
                 }
 
                 if (mismatchedOutputs.Count > 0)
                 {
-                    var resultInputs = step.Inputs.ToDictionary(o => o.Name, o => o.Value);
-                    var resultOutputs = step.Outputs.ToDictionary(o => o.Name, o => o.Value);
+                    var resultInputs = step.Inputs.ToDictionary(o => o.Name, o => o.Values.Select(v => v.Value).ToArray());
+                    var resultOutputs = step.Outputs.ToDictionary(o => o.Name, o => o.Values.Select(v => v.Value).ToArray());
 
                     return new FailedStepCaseResult(this, [.. machine.PrintOutput], stepsRan, step.Span, resultInputs, resultOutputs, mismatchedOutputs);
                 }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ input sel
 input'2 data
 output out
 
-assign out = sel ? data[0] : data[1]
+assign out = sel ? data{0} : data{1}
 ```
 
 # Syntax reference
@@ -101,6 +101,9 @@ They can be defined in one of three formats:
 The machine can interact with its surroundings through the use of inputs and outputs, and it can additionally store an arbitrary amount of data using registers.
 
 Inputs can only be read from, and outputs can only be written to. They have a size of 1 bit, however they can be grouped together and be represented as a single number. Registers can be written to and read from, they can have a size from 1 to 64 bits and they persist their value.
+
+You may additionally create input, output and register vectors, which are simply multiple ports of the same size grouped together.
+For instance, `input'3 in[5]` declares an input vector made of 5 numbers that are 3 bits wide for a total of 15 bits.
 
 ## Top-level declarations
 ### Ports
@@ -170,7 +173,9 @@ The body of the blocks mentioned above consists of multiple statements, one per 
 
 #### Port references
 
-To read readable (input and register) ports' value, you can use the same name that was specified in the declaration.
+To read readable (input and register) ports' value, simply use the same name that was specified in the declaration.
+
+To access port vectors you can use an index in square brackets after the name, e.g. `data[3]`.
 
 #### Operators
 
@@ -213,10 +218,10 @@ The slice expression can be used to get a number consisting of a subset of anoth
 In order to specify the starting reference, a `<` or `>` character can be inserted after the opening bracket to indicate "left" or "right" respectively; if neither is used, the latter will be assumed. The syntax is as follows:
 
 ```js
-[0]     // Get 1 bit starting from the 1st position from the right (the offset is inclusive)
-[0,3]   // Get 3 bits starting from the 1st position from the right
-[>4,3]  // Get 3 bits starting from the 5th position from the right
-[<2,2]  // Get 2 bits starting from the 3rd position from the left
+{0}     // Get 1 bit starting from the 1st position from the right (the offset is inclusive)
+{0,3}   // Get 3 bits starting from the 1st position from the right
+{>4,3}  // Get 3 bits starting from the 5th position from the right
+{<2,2}  // Get 2 bits starting from the 3rd position from the left
 ```
 
 #### Truncation
@@ -233,7 +238,7 @@ There's also a shortcut truncation assignment, which will truncate the right sid
 ```
 local $var'4
 
-$var '= 100 // Will truncate to 4 bits
+$var '= 100 // Equivalent to (100)'len($var)
 ```
 
 ### Statements
@@ -270,6 +275,10 @@ end
 Runs a list of statements a number of times, as defined by the "from" and "to" values. It assigns an increasing value to a local, which will be declared if it isn't already. The "from" value is inclusive, while the "to" value isn't. If the former is not specified, `0` will be assumed.
 
 ```lua
+for $i to 5
+    // ...
+end
+
 for $i from 0 to 5
     // ...
 end
@@ -287,7 +296,7 @@ end
 
 #### Break statement
 
-When used inside a `for` or `while` loop, it exits that loop. When used inside a `when` or `startup` block, it exits that block.
+When used inside a `for` or `while` loop, it exits that loop.
 
 #### Tasks
 

--- a/Tester/Program.cs
+++ b/Tester/Program.cs
@@ -32,7 +32,6 @@ namespace Tester
             new Interpreter(script, machine, true).Run();
 
             var program = Compiler.Compile(script);
-            Console.WriteLine(string.Join(", ", program));
 
             var scratch = new bool[Math.Max(machine.InputCount, machine.OutputCount)];
 

--- a/Tester/Program.cs
+++ b/Tester/Program.cs
@@ -25,8 +25,8 @@ namespace Tester
 
             var machine = new MyMachine
             {
-                InputCount = script.Inputs.Values.Sum(o => o.BitSize),
-                OutputCount = script.Outputs.Values.Sum(o => o.BitSize)
+                InputCount = script.RegisteredInputLength,
+                OutputCount = script.RegisteredOutputLength
             };
 
             new Interpreter(script, machine, true).Run();


### PR DESCRIPTION
This PR adds port vectors, which are groups of same-sized inputs, outputs or registers that can be accessed using square-bracket indexing, e.g. `my_input[3]`.

```
input'4 in[5]

len(in) == 20
len(in) / len(in[0]) == 5
```